### PR TITLE
:construction_worker: Deploy to GitHub pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: mv public/* . && rm -rf public
+      - run: echo "ordopro.fr" > CNAME
+      - name: Deploy to gh-pages branch
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Deploy to GitHub Pages"
+          git push origin HEAD:gh-pages --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Ordopro Website
+
+[![Deploy to GitHub Pages](https://github.com/mynotif/website/actions/workflows/deploy.yml/badge.svg)](https://github.com/mynotif/website/actions/workflows/deploy.yml)
+[![pages-build-deployment](https://github.com/mynotif/website/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/mynotif/website/actions/workflows/pages/pages-build-deployment)
+
+The code behind the landing/marketing website.
+
+- <https://mynotif.github.io/website>
+- <https://ordopro.fr>
+
+The code is served via GitHub Pages


### PR DESCRIPTION
Also map ordopro.fr APEX domain as a custom domain, see: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain

Pages had to be enabled in the settings:
https://github.com/mynotif/website/settings/pages

The domain configuration at Route53 level was handled via:
https://github.com/mynotif/mynotif-backend/pull/199